### PR TITLE
Fix: Bug in test model 12

### DIFF
--- a/cases/0012/_parameters.tsv
+++ b/cases/0012/_parameters.tsv
@@ -1,3 +1,4 @@
 parameterId	parameterScale	lowerBound	upperBound	nominalValue	estimate
 k1	lin	0	10	0.8	1
 k2	lin	0	10	0.6	1
+b0	lin	0	10	0	1


### PR DESCRIPTION
Change b0=1 to b0=0 in parameter file to overwrite SBML_fixed pars.