### PR TITLE
Round expected results

### DIFF
--- a/petabtests/cases/0001/_0001_solution.yaml
+++ b/petabtests/cases/0001/_0001_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.7918379836848569
-llh: -0.8475016971318833
+chi2: 0.79183798368486
+llh: -0.84750169713188
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0002/_0002_solution.yaml
+++ b/petabtests/cases/0002/_0002_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.11346973122770035
-llh: -3.7324889984325407
+chi2: 0.1134697312277
+llh: -3.73248899843254
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0003/_0003_solution.yaml
+++ b/petabtests/cases/0003/_0003_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 30.840820345020646
-llh: -15.871992877799777
+chi2: 30.84082034502065
+llh: -15.87199287779978
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0004/_0004_solution.yaml
+++ b/petabtests/cases/0004/_0004_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 7.710205086255161
-llh: -5.692979609536926
+chi2: 7.71020508625516
+llh: -5.69297960953693
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0005/_0005_solution.yaml
+++ b/petabtests/cases/0005/_0005_solution.yaml
@@ -1,4 +1,4 @@
-chi2: 0.16020461109628903
+chi2: 0.16020461109629
 llh: -1.91797937195749
 simulation_files:
 - _simulations.tsv

--- a/petabtests/cases/0007/_0007_solution.yaml
+++ b/petabtests/cases/0007/_0007_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.2682957616816964
-llh: -1.378941036858004
+chi2: 0.2682957616817
+llh: -1.378941036858
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0008/_0008_solution.yaml
+++ b/petabtests/cases/0008/_0008_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.0008184443851564
-llh: -1.1777832801267603
+chi2: 1.00081844438516
+llh: -1.17778328012676
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0009/_0009_solution.yaml
+++ b/petabtests/cases/0009/_0009_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.6128279546163969
-llh: -0.7579966825976534
+chi2: 0.6128279546164
+llh: -0.75799668259765
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0010/_0010_solution.yaml
+++ b/petabtests/cases/0010/_0010_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.5094134279439457
-llh: -1.2062894192614277
+chi2: 1.50941342794395
+llh: -1.20628941926143
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0011/_0011_solution.yaml
+++ b/petabtests/cases/0011/_0011_solution.yaml
@@ -1,4 +1,4 @@
-chi2: 5.983671215775451
+chi2: 5.98367121577545
 llh: -3.44341831317718
 simulation_files:
 - _simulations.tsv

--- a/petabtests/cases/0012/_0012_solution.yaml
+++ b/petabtests/cases/0012/_0012_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 2.653061944016744
-llh: -1.778113677297827
+chi2: 2.65306194401674
+llh: -1.77811367729783
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0013/_0013_solution.yaml
+++ b/petabtests/cases/0013/_0013_solution.yaml
@@ -1,5 +1,5 @@
 chi2: 44.67749724597132
-llh: -22.790331328275112
+llh: -22.79033132827511
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0014/_0014_solution.yaml
+++ b/petabtests/cases/0014/_0014_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.03167351934739428
-llh: -3.686295289831353
+chi2: 0.03167351934739
+llh: -3.68629528983135
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0015/_0015_solution.yaml
+++ b/petabtests/cases/0015/_0015_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.00791837983684857
-llh: -5.0607120811959705
+chi2: 0.00791837983685
+llh: -5.06071208119597
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0016/_0016_solution.yaml
+++ b/petabtests/cases/0016/_0016_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.44002969659920027
-llh: -0.7849262388960581
+chi2: 0.4400296965992
+llh: -0.78492623889606
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/0017/_0017_solution.yaml
+++ b/petabtests/cases/0017/_0017_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.5381137419081023
-llh: -1.220639576243506
+chi2: 1.5381137419081
+llh: -1.22063957624351
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0001/_0001_solution.yaml
+++ b/petabtests/cases/pysb/0001/_0001_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.7918379836848569
-llh: -0.8475016971318833
+chi2: 0.79183798368486
+llh: -0.84750169713188
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0002/_0002_solution.yaml
+++ b/petabtests/cases/pysb/0002/_0002_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.11346973122770035
-llh: -3.7324889984325407
+chi2: 0.1134697312277
+llh: -3.73248899843254
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0003/_0003_solution.yaml
+++ b/petabtests/cases/pysb/0003/_0003_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 30.840820345020646
-llh: -15.871992877799777
+chi2: 30.84082034502065
+llh: -15.87199287779978
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0004/_0004_solution.yaml
+++ b/petabtests/cases/pysb/0004/_0004_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 7.710205086255161
-llh: -5.692979609536926
+chi2: 7.71020508625516
+llh: -5.69297960953693
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0005/_0005_solution.yaml
+++ b/petabtests/cases/pysb/0005/_0005_solution.yaml
@@ -1,4 +1,4 @@
-chi2: 0.16020461109628903
+chi2: 0.16020461109629
 llh: -1.91797937195749
 simulation_files:
 - _simulations.tsv

--- a/petabtests/cases/pysb/0007/_0007_solution.yaml
+++ b/petabtests/cases/pysb/0007/_0007_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.2682957616816964
-llh: -1.378941036858004
+chi2: 0.2682957616817
+llh: -1.378941036858
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0008/_0008_solution.yaml
+++ b/petabtests/cases/pysb/0008/_0008_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.0008184443851564
-llh: -1.1777832801267603
+chi2: 1.00081844438516
+llh: -1.17778328012676
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0009/_0009_solution.yaml
+++ b/petabtests/cases/pysb/0009/_0009_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.6128279546163969
-llh: -0.7579966825976534
+chi2: 0.6128279546164
+llh: -0.75799668259765
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0010/_0010_solution.yaml
+++ b/petabtests/cases/pysb/0010/_0010_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.5094134279439457
-llh: -1.2062894192614277
+chi2: 1.50941342794395
+llh: -1.20628941926143
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0011/_0011_solution.yaml
+++ b/petabtests/cases/pysb/0011/_0011_solution.yaml
@@ -1,4 +1,4 @@
-chi2: 5.983671215775451
+chi2: 5.98367121577545
 llh: -3.44341831317718
 simulation_files:
 - _simulations.tsv

--- a/petabtests/cases/pysb/0012/_0012_solution.yaml
+++ b/petabtests/cases/pysb/0012/_0012_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 2.653061944016744
-llh: -1.778113677297827
+chi2: 2.65306194401674
+llh: -1.77811367729783
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0013/_0013_solution.yaml
+++ b/petabtests/cases/pysb/0013/_0013_solution.yaml
@@ -1,5 +1,5 @@
 chi2: 44.67749724597132
-llh: -22.790331328275112
+llh: -22.79033132827511
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0014/_0014_solution.yaml
+++ b/petabtests/cases/pysb/0014/_0014_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.03167351934739428
-llh: -3.686295289831353
+chi2: 0.03167351934739
+llh: -3.68629528983135
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0015/_0015_solution.yaml
+++ b/petabtests/cases/pysb/0015/_0015_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.00791837983684857
-llh: -5.0607120811959705
+chi2: 0.00791837983685
+llh: -5.06071208119597
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0016/_0016_solution.yaml
+++ b/petabtests/cases/pysb/0016/_0016_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 0.44002969659920027
-llh: -0.7849262388960581
+chi2: 0.4400296965992
+llh: -0.78492623889606
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/cases/pysb/0017/_0017_solution.yaml
+++ b/petabtests/cases/pysb/0017/_0017_solution.yaml
@@ -1,5 +1,5 @@
-chi2: 1.5381137419081023
-llh: -1.220639576243506
+chi2: 1.5381137419081
+llh: -1.22063957624351
 simulation_files:
 - _simulations.tsv
 tol_chi2: 0.001

--- a/petabtests/file.py
+++ b/petabtests/file.py
@@ -160,8 +160,11 @@ def write_solution(
     # solution yaml
     config = {
         SIMULATION_FILES: [],
-        CHI2: float(chi2),
-        LLH: float(llh),
+        # round to 14 significant digits, as the last 0 tend to be different
+        #  across different systems. avoid repeated modifications of otherwise
+        #  unrelated test cases
+        CHI2: round(float(chi2), 14),
+        LLH: round(float(llh), 14),
         TOL_SIMULATIONS: float(tol_simulations),
         TOL_CHI2: float(tol_chi2),
         TOL_LLH: float(tol_llh)


### PR DESCRIPTION
Round expected results to 14 significant digits, as the last 0 tend to be different across different systems. avoid repeated modifications of otherwise unrelated test cases