### PR TITLE
Show diff in case of not properly regenerated tests

### DIFF
--- a/test/test_generate.py
+++ b/test/test_generate.py
@@ -8,6 +8,7 @@ import subprocess
 def test_check_cases_up_to_date():
     sys.path.insert(0, CASES_DIR)
     create()
-    res = subprocess.run(['git', 'diff', CASES_DIR], capture_output=True)
+    res = subprocess.run(['git', 'diff', '--exit-code', CASES_DIR],
+                         capture_output=True)
     has_changes = res.returncode
-    assert not has_changes, res.stdout
+    assert not has_changes, res.stdout.decode()

--- a/test/test_generate.py
+++ b/test/test_generate.py
@@ -8,6 +8,6 @@ import subprocess
 def test_check_cases_up_to_date():
     sys.path.insert(0, CASES_DIR)
     create()
-    has_changes = subprocess.run(['git', 'diff', '--quiet',
-                                 CASES_DIR]).returncode
-    assert not has_changes
+    res = subprocess.run(['git', 'diff', CASES_DIR], capture_output=True)
+    has_changes = res.returncode
+    assert not has_changes, res.stdout


### PR DESCRIPTION
Old output (`assert not 1`) wasn't that helpful...