### PR TITLE
Add v1 test case 0020

### DIFF
--- a/petabtests/cases/v1.0.0/sbml/0020/0020.py
+++ b/petabtests/cases/v1.0.0/sbml/0020/0020.py
@@ -1,0 +1,98 @@
+from inspect import cleandoc
+
+import pandas as pd
+from petab.v1.C import *
+
+from petabtests import PetabTestCase, analytical_a, antimony_to_sbml_str
+from pathlib import Path
+
+DESCRIPTION = cleandoc("""
+## Objective
+
+This case tests handling of initial concentrations that are specified
+in the conditions table. For species `A`, the initial concentration is
+estimated. For species `B`, the initial concentration is specified as
+`NaN` in the condition table, thus the SBML model initial value should 
+be used.
+
+## Model
+
+A simple conversion reaction `A <=> B` in a single compartment, following
+mass action kinetics.
+""")
+
+# problem --------------------------------------------------------------------
+ant_model = """
+model *petab_test_0011()
+  compartment compartment_ = 1;
+  species A in compartment_, B in compartment_;
+
+  fwd: A => B; compartment_ * k1 * A;
+  rev: B => A; compartment_ * k2 * B;
+
+  A = a0;
+  B = 3;
+  a0 = 1;
+  k1 = 0;
+  k2 = 0;
+end
+"""
+model_file = Path(__file__).parent / "_model.xml"
+model_file.write_text(antimony_to_sbml_str(ant_model))
+
+condition_df = pd.DataFrame(
+    data={
+        CONDITION_ID: ["c0"],
+        "A": ["initial_A"],
+        "B": ["initial_B"],
+    }
+).set_index([CONDITION_ID])
+
+measurement_df = pd.DataFrame(
+    data={
+        OBSERVABLE_ID: ["obs_a", "obs_a"],
+        SIMULATION_CONDITION_ID: ["c0", "c0"],
+        TIME: [0, 10],
+        MEASUREMENT: [0.7, 0.1],
+    }
+)
+
+observable_df = pd.DataFrame(
+    data={
+        OBSERVABLE_ID: ["obs_a"],
+        OBSERVABLE_FORMULA: ["A"],
+        NOISE_FORMULA: [0.5],
+    }
+).set_index([OBSERVABLE_ID])
+
+parameter_df = pd.DataFrame(
+    data={
+        PARAMETER_ID: ["k1", "k2", "initial_A"],
+        PARAMETER_SCALE: [LIN, LIN, LOG10],
+        LOWER_BOUND: [0, 0, 1],
+        UPPER_BOUND: [10] * 3,
+        NOMINAL_VALUE: [0.8, 0.6, 2],
+        ESTIMATE: [1] * 3,
+    }
+).set_index(PARAMETER_ID)
+
+# solutions ------------------------------------------------------------------
+
+simulation_df = measurement_df.copy(deep=True).rename(
+    columns={MEASUREMENT: SIMULATION}
+)
+simulation_df[SIMULATION] = [
+    analytical_a(t, 2, 3, 0.8, 0.6) for t in simulation_df[TIME]
+]
+
+case = PetabTestCase(
+    id=20,
+    brief="Simulation. NaN in condition table for model without preequilibration.",
+    description=DESCRIPTION,
+    model=model_file,
+    condition_dfs=[condition_df],
+    observable_dfs=[observable_df],
+    measurement_dfs=[measurement_df],
+    simulation_dfs=[simulation_df],
+    parameter_df=parameter_df,
+)

--- a/petabtests/cases/v1.0.0/sbml/0020/README.md
+++ b/petabtests/cases/v1.0.0/sbml/0020/README.md
@@ -1,0 +1,14 @@
+# PEtab test case 0020
+
+## Objective
+
+This case tests handling of initial concentrations that are specified
+in the conditions table. For species `A`, the initial concentration is
+estimated. For species `B`, the initial concentration is specified as
+`NaN` in the condition table, thus the SBML model initial value should 
+be used.
+
+## Model
+
+A simple conversion reaction `A <=> B` in a single compartment, following
+mass action kinetics.

--- a/petabtests/cases/v1.0.0/sbml/0020/_0020.yaml
+++ b/petabtests/cases/v1.0.0/sbml/0020/_0020.yaml
@@ -1,0 +1,11 @@
+format_version: 1
+parameter_file: _parameters.tsv
+problems:
+- condition_files:
+  - _conditions.tsv
+  measurement_files:
+  - _measurements.tsv
+  observable_files:
+  - _observables.tsv
+  sbml_files:
+  - _model.xml

--- a/petabtests/cases/v1.0.0/sbml/0020/_0020_solution.yaml
+++ b/petabtests/cases/v1.0.0/sbml/0020/_0020_solution.yaml
@@ -1,0 +1,7 @@
+chi2: 23.45305928312484
+llh: -12.17811234685187
+simulation_files:
+- _simulations.tsv
+tol_chi2: 0.001
+tol_llh: 0.001
+tol_simulations: 0.001

--- a/petabtests/cases/v1.0.0/sbml/0020/_conditions.tsv
+++ b/petabtests/cases/v1.0.0/sbml/0020/_conditions.tsv
@@ -1,0 +1,2 @@
+conditionId	A	B
+c0	initial_A	NaN

--- a/petabtests/cases/v1.0.0/sbml/0020/_measurements.tsv
+++ b/petabtests/cases/v1.0.0/sbml/0020/_measurements.tsv
@@ -1,0 +1,3 @@
+observableId	simulationConditionId	time	measurement
+obs_a	c0	0	0.7
+obs_a	c0	10	0.1

--- a/petabtests/cases/v1.0.0/sbml/0020/_model.xml
+++ b/petabtests/cases/v1.0.0/sbml/0020/_model.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.14.0 with libSBML version 5.20.2. -->
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+  <model metaid="petab_test_0011" id="petab_test_0011">
+    <listOfCompartments>
+      <compartment id="compartment_" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="A" compartment="compartment_" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="B" compartment="compartment_" initialConcentration="3" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" value="0" constant="true"/>
+      <parameter id="k2" value="0" constant="true"/>
+      <parameter id="a0" value="1" constant="true"/>
+    </listOfParameters>
+    <listOfInitialAssignments>
+      <initialAssignment symbol="A">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <ci> a0 </ci>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments>
+    <listOfReactions>
+      <reaction id="fwd" reversible="false">
+        <listOfReactants>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="B" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment_ </ci>
+              <ci> k1 </ci>
+              <ci> A </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="rev" reversible="false">
+        <listOfReactants>
+          <speciesReference species="B" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="A" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment_ </ci>
+              <ci> k2 </ci>
+              <ci> B </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/petabtests/cases/v1.0.0/sbml/0020/_observables.tsv
+++ b/petabtests/cases/v1.0.0/sbml/0020/_observables.tsv
@@ -1,0 +1,2 @@
+observableId	observableFormula	noiseFormula
+obs_a	A	0.5

--- a/petabtests/cases/v1.0.0/sbml/0020/_parameters.tsv
+++ b/petabtests/cases/v1.0.0/sbml/0020/_parameters.tsv
@@ -1,0 +1,4 @@
+parameterId	parameterScale	lowerBound	upperBound	nominalValue	estimate
+k1	lin	0	10	0.8	1
+k2	lin	0	10	0.6	1
+initial_A	log10	1	10	2.0	1

--- a/petabtests/cases/v1.0.0/sbml/0020/_simulations.tsv
+++ b/petabtests/cases/v1.0.0/sbml/0020/_simulations.tsv
@@ -1,0 +1,3 @@
+observableId	simulationConditionId	time	simulation
+obs_a	c0	0	2.0
+obs_a	c0	10	2.1428570240673257

--- a/petabtests/cases/v1.0.0/sbml/README.md
+++ b/petabtests/cases/v1.0.0/sbml/README.md
@@ -74,3 +74,6 @@ Simulation. Preequilibration and RateRules. One state reinitialized, one not (Na
 
 Simulation. Estimated initial value via conditions table.
 
+# [0020](0020/)
+
+Simulation. NaN for initial value in condition table.


### PR DESCRIPTION
Quoiting the spec for the condition table:

*If NaN is provided for a condition, the result of the preequilibration (or initial condition from the SBML model, if no preequilibration is defined) is used.*

The latter case is currently not tested, and this PR adds a test for it.